### PR TITLE
[js] file names should not be the same as was in cutes-js

### DIFF
--- a/rpm/cutes-qt5.spec
+++ b/rpm/cutes-qt5.spec
@@ -52,6 +52,10 @@ make %{?jobs:-j%jobs}
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
+pushd %{buildroot}/%{jslibdir}
+# for backward compatibility
+ln -s qt-core.js qtcore.js
+popd
 
 %clean
 rm -rf %{buildroot}

--- a/src/lib/.gitignore
+++ b/src/lib/.gitignore
@@ -1,4 +1,4 @@
 core.cpp
-qtcore.js
+qt-core.js
 test_core_linking
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,9 +1,9 @@
 set(CMAKE_AUTOMOC TRUE)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-MACRO(GENERATE_BRIDGE _name)
+MACRO(GENERATE_BRIDGE _name _qt_lib)
   set(_tgt ${_name}.cpp)
-  set(_js qt${_name}.js)
+  set(_js qt-${_name}.js)
   set(_dst ${CMAKE_CURRENT_SOURCE_DIR}/${_tgt})
   set(_js_file ${CMAKE_CURRENT_SOURCE_DIR}/${_js})
   set(_src ${CMAKE_CURRENT_SOURCE_DIR}/${_name}.cpp.in)
@@ -14,21 +14,24 @@ MACRO(GENERATE_BRIDGE _name)
     DEPENDS ${_src} ${_gen_script}
     )
   qt5_generate_moc(${_tgt} ${_name}.moc)
+
+  add_library(cutes-${_name} SHARED ${_name}.cpp ${_name}.moc)
+  qt5_use_modules(cutes-${_name} ${_qt_lib} Qml)
+
+  target_link_libraries(cutes-${_name}
+    cutes-qt5
+    -ldl
+    )
+
+  install(TARGETS cutes-${_name} DESTINATION ${DST_LIB}/qt5/cutes/qt)
+  install(FILES qt-${_name}.js DESTINATION share/cutes)
+
 ENDMACRO(GENERATE_BRIDGE)
 
-generate_bridge(core)
-add_library(cutes-core SHARED core.cpp core.moc)
-qt5_use_modules(cutes-core Core Qml)
-
-target_link_libraries(cutes-core
-  cutes-qt5
-  -ldl
-)
+generate_bridge(core Core)
 
 add_executable(test_core_linking test_linking.cpp)
 target_link_libraries(test_core_linking cutes-core cutes-qt5)
 
-install(TARGETS cutes-core DESTINATION ${DST_LIB}/qt5/cutes/qt)
-install(FILES qtcore.js DESTINATION share/cutes)
 install(FILES wrap-qt.js DESTINATION share/cutes)
 install(PROGRAMS preprocess_bridge.py DESTINATION ${DST_LIB}/cutes/bin)

--- a/src/tests/actor_extend.js
+++ b/src/tests/actor_extend.js
@@ -1,4 +1,4 @@
-var Q = cutes.require("qtcore");
+var Q = cutes.require("qt-core");
 
 exports = function(msg, ctx) {
     return msg + ",ok";

--- a/src/tests/actor_extend.qml
+++ b/src/tests/actor_extend.qml
@@ -5,7 +5,7 @@ CutesActor {
     id: actor
     source: "actor_extend.js"
     Component.onCompleted: {
-        var Q = cutes.require("qtcore");
+        var Q = cutes.require("qt-core");
         actor.send("Ping", { on_reply: function(v) {
             console.log("Normal exit: got " + v)
             cutes.exit(0);

--- a/src/tests/test_bridge.js
+++ b/src/tests/test_bridge.js
@@ -1,4 +1,4 @@
-var Q = require('qtcore');
+var Q = require('qt-core');
 
 var get_actor = function() {
     var actor = cutes.actor();

--- a/src/tests/use-qtcore.js
+++ b/src/tests/use-qtcore.js
@@ -1,3 +1,3 @@
-var Q = require('qtcore')
+var Q = require('qt-core')
 if (!Q)
     throw new Error("Q is not defined but " + Q);


### PR DESCRIPTION
To avoid package upgrade collisions rename qtcore.js to qt-core.js
because file with the same name was provided by the previous version
of cutes-js.

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
